### PR TITLE
add country code to weather request

### DIFF
--- a/src/components/CountriesSingle.jsx
+++ b/src/components/CountriesSingle.jsx
@@ -38,7 +38,9 @@ const CountriesSingle = () => {
         .get(
           `https://api.openweathermap.org/data/2.5/weather?q=${encodeURIComponent(
             country.capital[0]
-          )}&units=metric&appid=${process.env.REACT_APP_OPENWEATHER_KEY}`
+          )},${country.cca2}&units=metric&appid=${
+            process.env.REACT_APP_OPENWEATHER_KEY
+          }`
         )
         .then((res) => {
           setWeather(res.data);
@@ -64,7 +66,7 @@ const CountriesSingle = () => {
             });
         });
     }
-  }, [country.capital, country.name.common]);
+  }, [country.capital, country.name.common, country.cca2]);
 
   if (weather) {
     const sunriseDate = new Date(weather.sys.sunrise * 1000);


### PR DESCRIPTION
In case the API fetches weather info for wrong city that has the same name. For example there are lots of cities called Dublin in United States.